### PR TITLE
Make compatible with Django 1.8

### DIFF
--- a/discover_jenkins/tasks/run_flake8.py
+++ b/discover_jenkins/tasks/run_flake8.py
@@ -4,18 +4,21 @@ import sys
 import pep8
 from flake8.engine import get_style_guide
 from optparse import make_option
+import django
 from discover_jenkins.tasks.run_pep8 import Pep8Task
 from discover_jenkins.utils import get_app_locations
 
 
 class Flake8Task(Pep8Task):
-    option_list = Pep8Task.option_list + (
-        make_option(
-            '--max-complexity',
-            dest='max_complexity',
-            help='McCabe complexity threshold',
-        ),
-    )
+
+    if django.VERSION < (1, 8):
+        option_list = Pep8Task.option_list + (
+            make_option(
+                '--max-complexity',
+                dest='max_complexity',
+                help='McCabe complexity threshold',
+            ),
+        )
 
     def __init__(self, **options):
         super(Flake8Task, self).__init__(**options)
@@ -30,6 +33,13 @@ class Flake8Task(Pep8Task):
 
         if options['max_complexity']:
             self.pep8_options['max_complexity'] = int(options['max_complexity'])
+
+    @classmethod
+    def add_arguments(cls, parser):
+        Pep8Task.add_arguments(parser)
+        parser.add_argument('--max-complexity',
+            dest='max_complexity',
+            help='McCabe complexity threshold')
 
     def teardown_test_environment(self, **kwargs):
         class JenkinsReport(pep8.BaseReport):

--- a/discover_jenkins/tasks/run_jshint.py
+++ b/discover_jenkins/tasks/run_jshint.py
@@ -6,6 +6,7 @@ import fnmatch
 import subprocess
 from optparse import make_option
 
+import django
 from django.conf import settings as django_settings
 
 from ..utils import CalledProcessError, get_app_locations
@@ -13,41 +14,43 @@ from ..settings import JSHINT_CHECKED_FILES, JSHINT_RCFILE, JSHINT_EXCLUDE
 
 
 class JSHintTask(object):
-    option_list = (
-        make_option(
-            "--jshint-no-staticdirs",
-            dest="jshint-no-staticdirs",
-            default=False,
-            action="store_true",
-            help="Don't check js files located in STATICFILES_DIRS settings"
-        ),
-        make_option(
-            "--jshint-with-minjs",
-            dest="jshint_with-minjs",
-            default=False,
-            action="store_true",
-            help="Do not ignore .min.js files"
-        ),
-        make_option(
-            "--jshint-exclude",
-            dest="jshint_exclude",
-            default=JSHINT_EXCLUDE,
-            help="Exclude patterns"
-        ),
-        make_option(
-            '--jshint-stdout',
-            action='store_true',
-            dest='jshint_stdout',
-            default=False,
-            help='Print the jshint output instead of storing it in a file'
-        ),
-        make_option(
-            '--jshint-rcfile',
-            dest='jshint_rcfile',
-            default=JSHINT_RCFILE,
-            help='Provide an rcfile for jshint'
-        ),
-    )
+
+    if django.VERSION < (1, 8):
+        option_list = (
+            make_option(
+                "--jshint-no-staticdirs",
+                dest="jshint-no-staticdirs",
+                default=False,
+                action="store_true",
+                help="Don't check js files located in STATICFILES_DIRS settings"
+            ),
+            make_option(
+                "--jshint-with-minjs",
+                dest="jshint_with-minjs",
+                default=False,
+                action="store_true",
+                help="Do not ignore .min.js files"
+            ),
+            make_option(
+                "--jshint-exclude",
+                dest="jshint_exclude",
+                default=JSHINT_EXCLUDE,
+                help="Exclude patterns"
+            ),
+            make_option(
+                '--jshint-stdout',
+                action='store_true',
+                dest='jshint_stdout',
+                default=False,
+                help='Print the jshint output instead of storing it in a file'
+            ),
+            make_option(
+                '--jshint-rcfile',
+                dest='jshint_rcfile',
+                default=JSHINT_RCFILE,
+                help='Provide an rcfile for jshint'
+            ),
+        )
 
     def __init__(self, **options):
         self.to_stdout = options['jshint_stdout']
@@ -67,6 +70,24 @@ class JSHintTask(object):
         self.exclude = options['jshint_exclude']
         if isinstance(self.exclude, str):
             self.exclude = self.exclude.split(',')
+
+    @classmethod
+    def add_arguments(cls, parser):
+        parser.add_argument("--jshint-no-staticdirs",
+            dest="jshint-no-staticdirs", default=False, action="store_true",
+            help="Don't check js files located in STATICFILES_DIRS settings")
+        parser.add_argument("--jshint-with-minjs",
+            dest="jshint_with-minjs", default=False, action="store_true",
+            help="Do not ignore .min.js files")
+        parser.add_argument("--jshint-exclude",
+            dest="jshint_exclude", default=JSHINT_EXCLUDE,
+            help="Exclude patterns")
+        parser.add_argument('--jshint-stdout',
+            action='store_true', dest='jshint_stdout', default=False,
+            help='Print the jshint output instead of storing it in a file')
+        parser.add_argument('--jshint-rcfile',
+            dest='jshint_rcfile', default=JSHINT_RCFILE,
+            help='Provide an rcfile for jshint')
 
     def teardown_test_environment(self, **kwargs):
         files = [path for path in self.static_files_iterator()]

--- a/discover_jenkins/tasks/run_pep8.py
+++ b/discover_jenkins/tasks/run_pep8.py
@@ -3,39 +3,42 @@ import os
 import sys
 import pep8
 from optparse import make_option
+import django
 from django.conf import settings
 from discover_jenkins.utils import check_output, get_app_locations
 
 
 class Pep8Task(object):
-    option_list = (
-        make_option(
-            "--pep8-exclude",
-            dest="pep8-exclude",
-            default=pep8.DEFAULT_EXCLUDE + ",migrations",
-            help="exclude files or directories which match these "
-                 "comma separated patterns (default: %s)" %
-                 pep8.DEFAULT_EXCLUDE
-        ),
-        make_option(
-            "--pep8-select", dest="pep8-select",
-            help="select errors and warnings (e.g. E,W6)",
-        ),
-        make_option(
-            "--pep8-ignore", dest="pep8-ignore",
-            help="skip errors and warnings (e.g. E4,W)",
-        ),
-        make_option(
-            "--pep8-max-line-length",
-            dest="pep8-max-line-length", type='int',
-            help="set maximum allowed line length (default: %d)" %
-                 pep8.MAX_LINE_LENGTH
-        ),
-        make_option(
-            "--pep8-rcfile", dest="pep8-rcfile",
-            help="PEP8 configuration file"
-        ),
-    )
+
+    if django.VERSION < (1, 8):
+        option_list = (
+            make_option(
+                "--pep8-exclude",
+                dest="pep8-exclude",
+                default=pep8.DEFAULT_EXCLUDE + ",migrations",
+                help="exclude files or directories which match these "
+                     "comma separated patterns (default: %s)" %
+                     pep8.DEFAULT_EXCLUDE
+            ),
+            make_option(
+                "--pep8-select", dest="pep8-select",
+                help="select errors and warnings (e.g. E,W6)",
+            ),
+            make_option(
+                "--pep8-ignore", dest="pep8-ignore",
+                help="skip errors and warnings (e.g. E4,W)",
+            ),
+            make_option(
+                "--pep8-max-line-length",
+                dest="pep8-max-line-length", type='int',
+                help="set maximum allowed line length (default: %d)" %
+                     pep8.MAX_LINE_LENGTH
+            ),
+            make_option(
+                "--pep8-rcfile", dest="pep8-rcfile",
+                help="PEP8 configuration file"
+            ),
+        )
 
     def __init__(self, **options):
         if options.get('pep8_file_output', True):
@@ -55,6 +58,25 @@ class Pep8Task(object):
         if options['pep8-max-line-length']:
             self.pep8_options['max_line_length'] = \
                                                 options['pep8-max-line-length']
+
+    @classmethod
+    def add_arguments(cls, parser):
+        parser.add_argument("--pep8-exclude",
+            dest="pep8-exclude",
+            default=pep8.DEFAULT_EXCLUDE + ",migrations",
+            help="exclude files or directories which match these "
+                 "comma separated patterns (default: %s)" %
+                 pep8.DEFAULT_EXCLUDE)
+        parser.add_argument("--pep8-select", dest="pep8-select",
+            help="select errors and warnings (e.g. E,W6)")
+        parser.add_argument("--pep8-ignore", dest="pep8-ignore",
+            help="skip errors and warnings (e.g. E4,W)")
+        parser.add_argument("--pep8-max-line-length",
+            dest="pep8-max-line-length", type='int',
+            help="set maximum allowed line length (default: %d)" %
+                 pep8.MAX_LINE_LENGTH)
+        parser.add_argument("--pep8-rcfile", dest="pep8-rcfile",
+            help="PEP8 configuration file")
 
     def teardown_test_environment(self, **kwargs):
         locations = get_app_locations()

--- a/discover_jenkins/tasks/run_pylint.py
+++ b/discover_jenkins/tasks/run_pylint.py
@@ -4,6 +4,8 @@ import os
 import sys
 from optparse import make_option
 
+import django
+
 from pylint import lint
 from pylint.reporters.text import ParseableTextReporter
 
@@ -21,21 +23,23 @@ def default_config_path():
 
 
 class PyLintTask(object):
-    option_list = (
-        make_option(
-            "--pylint-rcfile",
-            dest="pylint_rcfile",
-            default=None,
-            help="pylint configuration file"
-        ),
-        make_option(
-            "--pylint-errors-only",
-            dest="pylint_errors_only",
-            action="store_true",
-            default=False,
-            help="pylint output errors only mode"
-        ),
-    )
+
+    if django.VERSION < (1, 8):
+        option_list = (
+            make_option(
+                "--pylint-rcfile",
+                dest="pylint_rcfile",
+                default=None,
+                help="pylint configuration file"
+            ),
+            make_option(
+                "--pylint-errors-only",
+                dest="pylint_errors_only",
+                action="store_true",
+                default=False,
+                help="pylint output errors only mode"
+            ),
+        )
 
     def __init__(self, **options):
         self.config_path = options['pylint_rcfile'] or default_config_path()
@@ -48,6 +52,15 @@ class PyLintTask(object):
             self.output = open(os.path.join(output_dir, 'pylint.report'), 'w')
         else:
             self.output = sys.stdout
+
+    @classmethod
+    def add_arguments(cls, parser):
+        parser.add_argument("--pylint-rcfile",
+            dest="pylint_rcfile", default=None,
+            help="pylint configuration file")
+        parser.add_argument("--pylint-errors-only",
+            dest="pylint_errors_only", action="store_true", default=False,
+            help="pylint output errors only mode")
 
     def teardown_test_environment(self, **kwargs):
         if PROJECT_APPS:

--- a/discover_jenkins/tasks/run_sloccount.py
+++ b/discover_jenkins/tasks/run_sloccount.py
@@ -2,27 +2,29 @@
 import os
 import sys
 from optparse import make_option
-
+import django
 from discover_jenkins.utils import check_output, get_app_locations
 
 
 class SlocCountTask(object):
-    option_list = (
-        make_option(
-            "--sloccount-with-migrations",
-            action="store_true",
-            default=False,
-            dest="sloccount_with_migrations",
-            help="Count migrations sloc."
-        ),
-        make_option(
-            '--sloccount-stdout',
-            action='store_true',
-            dest='sloccount_stdout',
-            default=False,
-            help='Print the sloccount totals instead of saving them to a file'
-        ),
-    )
+
+    if django.VERSION < (1, 8):
+        option_list = (
+            make_option(
+                "--sloccount-with-migrations",
+                action="store_true",
+                default=False,
+                dest="sloccount_with_migrations",
+                help="Count migrations sloc."
+            ),
+            make_option(
+                '--sloccount-stdout',
+                action='store_true',
+                dest='sloccount_stdout',
+                default=False,
+                help='Print the sloccount totals instead of saving them to a file'
+            ),
+        )
 
     def __init__(self, **options):
         self.with_migrations = options['sloccount_with_migrations']
@@ -35,6 +37,16 @@ class SlocCountTask(object):
                 os.makedirs(output_dir)
             self.output = open(os.path.join(output_dir,
                                             'sloccount.report'), 'w')
+
+    @classmethod
+    def add_arguments(cls, parser):
+        parser.add_argument("--sloccount-with-migrations",
+            action="store_true", default=False, dest="sloccount_with_migrations",
+            help="Count migrations sloc."
+        )
+        parser.add_argument("--sloccount-stdout",
+            action="store_true", dest="sloccount_stdout", default=False,
+            help="Print the sloccount totals instead of saving them to a file")
 
     def teardown_test_environment(self, **kwargs):
         locations = get_app_locations()

--- a/discover_jenkins/tasks/with_coverage.py
+++ b/discover_jenkins/tasks/with_coverage.py
@@ -4,6 +4,7 @@ import os
 from optparse import make_option
 
 from coverage.control import coverage
+import django
 
 from .. import settings
 
@@ -16,42 +17,44 @@ def default_config_path():
 
 
 class CoverageTask(object):
-    option_list = (
-        make_option(
-            "--coverage-rcfile",
-            dest="coverage_rcfile",
-            default="",
-            help="Specify configuration file."
-        ),
-        make_option(
-            "--coverage-html-report",
-            dest="coverage_html_report_dir",
-            default=settings.COVERAGE_REPORT_HTML_DIR,
-            help="Directory to which HTML coverage report should be"
-            " written. If not specified, no report is generated."
-        ),
-        make_option(
-            "--coverage-no-branch-measure",
-            action="store_false",
-            default=settings.COVERAGE_MEASURE_BRANCH,
-            dest="coverage_measure_branch",
-            help="Don't measure branch coverage."
-        ),
-        make_option(
-            "--coverage-with-migrations",
-            action="store_true",
-            default=settings.COVERAGE_WITH_MIGRATIONS,
-            dest="coverage_with_migrations",
-            help="Don't measure migrations coverage."
-        ),
-        make_option(
-            "--coverage-exclude",
-            action="append",
-            default=settings.COVERAGE_EXCLUDE_PATHS,
-            dest="coverage_excludes",
-            help="Paths to be excluded from coverage"
+
+    if django.VERSION < (1, 8):
+        option_list = (
+            make_option(
+                "--coverage-rcfile",
+                dest="coverage_rcfile",
+                default="",
+                help="Specify configuration file."
+            ),
+            make_option(
+                "--coverage-html-report",
+                dest="coverage_html_report_dir",
+                default=settings.COVERAGE_REPORT_HTML_DIR,
+                help="Directory to which HTML coverage report should be"
+                " written. If not specified, no report is generated."
+            ),
+            make_option(
+                "--coverage-no-branch-measure",
+                action="store_false",
+                default=settings.COVERAGE_MEASURE_BRANCH,
+                dest="coverage_measure_branch",
+                help="Don't measure branch coverage."
+            ),
+            make_option(
+                "--coverage-with-migrations",
+                action="store_true",
+                default=settings.COVERAGE_WITH_MIGRATIONS,
+                dest="coverage_with_migrations",
+                help="Don't measure migrations coverage."
+            ),
+            make_option(
+                "--coverage-exclude",
+                action="append",
+                default=settings.COVERAGE_EXCLUDE_PATHS,
+                dest="coverage_excludes",
+                help="Paths to be excluded from coverage"
+            )
         )
-    )
 
     def __init__(self, **options):
         self.output_dir = options['output_dir']
@@ -67,6 +70,28 @@ class CoverageTask(object):
             omit=self.exclude_locations,
             config_file=options.get('coverage_rcfile') or default_config_path()
         )
+
+    @classmethod
+    def add_arguments(cls, parser):
+        parser.add_argument("--coverage-rcfile",
+            dest="coverage_rcfile", default="",
+            help="Specify configuration file.")
+        parser.add_argument("--coverage-html-report",
+            dest="coverage_html_report_dir", default=settings.COVERAGE_REPORT_HTML_DIR,
+            help="Directory to which HTML coverage report should be"
+                 " written. If not specified, no report is generated.")
+        parser.add_argument("--coverage-no-branch-measure",
+            action="store_false", default=settings.COVERAGE_MEASURE_BRANCH,
+            dest="coverage_measure_branch",
+            help="Don't measure branch coverage.")
+        parser.add_argument("--coverage-with-migrations",
+            action="store_true", default=settings.COVERAGE_WITH_MIGRATIONS,
+            dest="coverage_with_migrations",
+            help="Don't measure migrations coverage.")
+        parser.add_argument("--coverage-exclude",
+            action="append", default=settings.COVERAGE_EXCLUDE_PATHS,
+            dest="coverage_excludes",
+            help="Paths to be excluded from coverage")
 
     def setup_test_environment(self, **kwargs):
         self.coverage.start()


### PR DESCRIPTION
In Django 1.8, `DiscoverRunner.option_list` is replaced with the classmethod `DiscoverRunner.add_arguments()`